### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,7 +36,7 @@ func NewCoapPubsubClient(servAddr string) *CoapPubsubClient {
 	return c
 }
 
-//Add Subscription on topic and return a channel for user to wait data
+//AddSub adds Subscription on topic and return a channel for user to wait data
 func (c *CoapPubsubClient) AddSub(topic string) (chan string, error) {
 	if val, exist := c.subList[topic]; exist {
 		//if topic already exist in sub, return and not send to server
@@ -57,7 +57,7 @@ func (c *CoapPubsubClient) AddSub(topic string) (chan string, error) {
 	return subChan, nil
 }
 
-//Remove Subscribetion on topic
+//RemoveSub removes Subscribetion on topic
 func (c *CoapPubsubClient) RemoveSub(topic string) error {
 	if _, exist := c.subList[topic]; !exist {
 		//if topic not in sub list, return and not send to server

--- a/server.go
+++ b/server.go
@@ -147,7 +147,7 @@ func (c *CoapPubsubServer) handleCoAPMessage(l *net.UDPConn, a *net.UDPAddr, m *
 	return nil
 }
 
-//Start to listen udp port and serve request, until faltal eror occur
+//ListenAndServe starts to listen udp port and serve request, until faltal eror occur
 func (c *CoapPubsubServer) ListenAndServe(udpPort string) {
 	log.Fatal(coap.ListenAndServe("udp", udpPort,
 		coap.FuncHandler(func(l *net.UDPConn, a *net.UDPAddr, m *coap.Message) *coap.Message {

--- a/tool.go
+++ b/tool.go
@@ -22,13 +22,13 @@ func ParseUint8ToString(in interface{}) string {
 	}
 }
 
-//Get random number locally
+//GetLocalRandomInt gets random number locally
 func GetLocalRandomInt() uint16 {
 	rand.Seed(time.Now().UnixNano())
 	return uint16(rand.Intn(1000))
 }
 
-//Get local IPV4 address to uint16 by <<8
+//GetIPv4Int16 gets local IPV4 address to uint16 by <<8
 func GetIPv4Int16() uint16 {
 
 	ifaces, err := net.Interfaces()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?